### PR TITLE
[FEAT] Duplo click com objetivo de limpar o estilo do block (voltando ele para a cor branca)

### DIFF
--- a/script.js
+++ b/script.js
@@ -14,6 +14,10 @@ function block(x, y) {
     span.style.backgroundColor = $selectedColor;
   }
 
+  span.ondblclick = () => {
+    span.style.backgroundColor = '#ffffff';
+  }
+
   span.onmouseover = e => {
     if (e.buttons == 1 || e.buttons == 3) {
       span.style.backgroundColor = $selectedColor;

--- a/script.js
+++ b/script.js
@@ -13,9 +13,8 @@ function block(x, y) {
   span.onclick = () => {
     span.style.backgroundColor = $selectedColor;
   }
-
   span.ondblclick = () => {
-    span.style.backgroundColor = '#ffffff';
+    span.removeAttribute("style")
   }
 
   span.onmouseover = e => {

--- a/script.js
+++ b/script.js
@@ -13,6 +13,7 @@ function block(x, y) {
   span.onclick = () => {
     span.style.backgroundColor = $selectedColor;
   }
+
   span.ondblclick = () => {
     span.removeAttribute("style")
   }


### PR DESCRIPTION
Funcionalidade que permite limpar a cor atual do block voltando ele para a cor branca. Para isso, remove o atributo style do elemento block.